### PR TITLE
Migrated documentation to mkdocs for all required versions

### DIFF
--- a/.github/workflows/build_mkdocs.yaml
+++ b/.github/workflows/build_mkdocs.yaml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.11
       - run: |
           pip install .[docs]
       - run: mkdocs gh-deploy --config-file mkdocs.yml --force

--- a/docs/advanced/index.md
+++ b/docs/advanced/index.md
@@ -5,6 +5,7 @@ You can read more detailed information about the methods implemented in TopoStat
 - [Flattening](flattening.md)
 - [Grain Finding](grain_finding.md)
 - [Thresholding](thresholding.md)
+- [Grain Stats](grainstats.md)
 - [Disordered Tracing](disordered_tracing.md)
 - [Nodestats](nodestats.md)
 - [Ordered Tracing](ordered_tracing.md)

--- a/docs/api/entry_point.md
+++ b/docs/api/entry_point.md
@@ -1,8 +1,3 @@
 # Entry Point Modules
 
 ::: topostats.entry_point
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/filters.md
+++ b/docs/api/filters.md
@@ -1,8 +1,3 @@
 # Filters Modules
 
 ::: topostats.filters
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/grains.md
+++ b/docs/api/grains.md
@@ -1,8 +1,3 @@
 # Grains Modules
 
 ::: topostats.grains
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/grainstats.md
+++ b/docs/api/grainstats.md
@@ -1,8 +1,3 @@
 # Grainstats Modules
 
 ::: topostats.grainstats
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/io.md
+++ b/docs/api/io.md
@@ -1,8 +1,3 @@
 # IO Modules
 
 ::: topostats.io
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -1,8 +1,3 @@
 # Plotting Modules
 
 ::: topostats.plotting
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/plottingfuncs.md
+++ b/docs/api/plottingfuncs.md
@@ -1,8 +1,3 @@
 # Plottingfuncs Modules
 
 ::: topostats.plottingfuncs
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/run_modules.md
+++ b/docs/api/run_modules.md
@@ -1,8 +1,0 @@
-# Run Modules Module
-
-::: topostats.run_modules
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/run_modules.md
+++ b/docs/api/run_modules.md
@@ -1,0 +1,3 @@
+# Run Modules Module
+
+::: topostats.run_modules

--- a/docs/api/run_topostats.md
+++ b/docs/api/run_topostats.md
@@ -1,0 +1,3 @@
+# Run TopoStats Module
+
+::: topostats.run_topostats

--- a/docs/api/run_topostats.md
+++ b/docs/api/run_topostats.md
@@ -1,3 +1,0 @@
-# Run TopoStats Module
-
-::: topostats.run_topostats

--- a/docs/api/scars.md
+++ b/docs/api/scars.md
@@ -1,8 +1,3 @@
 # Scars Module
 
 ::: topostats.scars
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/statistics.md
+++ b/docs/api/statistics.md
@@ -1,8 +1,3 @@
 # Statistics Modules
 
 ::: topostats.statistics
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/theme.md
+++ b/docs/api/theme.md
@@ -1,8 +1,3 @@
 # Theme Modules
 
 ::: topostats.theme
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/thresholds.md
+++ b/docs/api/thresholds.md
@@ -1,8 +1,3 @@
 # Thresholds Modules
 
 ::: topostats.thresholds
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -1,8 +1,3 @@
 # Utils Modules
 
 ::: topostats.utils
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/docs/api/validation.md
+++ b/docs/api/validation.md
@@ -1,8 +1,3 @@
 # Validation Module
 
 ::: topostats.validation
-handler: python
-options:
-docstring_style: numpy
-rendering:
-show_signature_annotations: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - advanced/flattening.md
       - advanced/grain_finding.md
       - advanced/thresholding.md
+      - advanced/grainstats.md
       - advanced/disordered_tracing.md
       - advanced/nodestats.md
       - advanced/ordered_tracing.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - IO: api/io.md
       - Plotting: api/plotting.md
       - PlottingFuncs: api/plottingfuncs.md
-      - Run Modules: api/run_modules.md
+      - Run TopoStats: api/run_topostats.md
       - Scars: api/scars.md
       - Statistics: api/statistics.md
       - Theme: api/theme.md
@@ -70,7 +70,12 @@ extra:
 plugins:
   - mermaid2
   - search
-  - mkdocstrings
+  - mkdocstrings:
+      handlers:
+       python:
+         options:
+           docstring_style: numpy
+           show_signature_annotations: true
   - mike:
       version_selector: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,7 +55,7 @@ nav:
       - IO: api/io.md
       - Plotting: api/plotting.md
       - PlottingFuncs: api/plottingfuncs.md
-      - Run TopoStats: api/run_topostats.md
+      - Run Modules: api/run_modules.md
       - Scars: api/scars.md
       - Statistics: api/statistics.md
       - Theme: api/theme.md


### PR DESCRIPTION
# TopoStats Pull Requests

Documentation has been converted and deployed with `mike` and `mkdocs` for the following TopoStats versions:

- v2.0.0
- v2.1.0
- v2.1.1
- v2.1.2
- v2.2.0
- v2.2.1
- v2.2.post0
- v2.3.1
- main

Navigating to the root page of the documentation also automatically naviagates to `/latest/` (currently v2.3.1)

Code blocks are now also colour-coded.

The live site from my fork can be seen here: https://tobyallwood.github.io/TopoStats/

---

Before submitting a Pull Request please check the following.

- [x] Documentation has been updated and builds.
